### PR TITLE
Add requirements.txt for Python dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+matplotlib==3.10.8
+numpy==2.4.0


### PR DESCRIPTION
Add a `requirements.txt` file to simplify installing Python dependencies using:
```
pip install -r requirements.txt
```

This avoids the need to install each dependency manually and makes setup faster and more reproducible.


>[!NOTE]
>Although this is a personal hobby project, I couldn’t resist submitting this PR.
>I’m deeply grateful for your contributions to the world and to the tech community. `Git` and `Linux` are part of my everyday work, so please consider this PR a small **thank you** from me.


Signed-off-by: NourCheriff <nourcherif.pitos25@gmail.com>