### PR TITLE
Fix: Add -lm linker flag to Makefile to resolve undefined reference to 'sin'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,6 @@ gensin.h: gensin
 	./gensin > gensin.h
 
 gensin: gensin.c
+	gcc -Wall gensin.c -o gensin -lm
 
 .PHONY: default play $(effects) SeymourDuncan visualize


### PR DESCRIPTION
Fix: Explicitly link the math library (-lm)

The GCC compiler requires the math library to be linked explicitly and typically placed after the source files in the command line arguments. This commit adds the `-lm` flag at the end of the gensin build command to resolve the "undefined reference to 'sin'" linker error.