### PR TITLE
Add tremolo effect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,16 @@ LDLIBS = -lm
 PYTHON = python3
 PLAY = ffplay -v fatal -nodisp -autoexit -f s32le -ar 48000 -ch_layout mono -i pipe:0
 
-effects = flanger echo fm phaser discont am
+effects = flanger echo fm phaser discont am tremolo
 flanger_defaults = 0.6 0.6 0.6 0.6
 echo_defaults = 0.3 0.3 0.3 0.3
 fm_defaults = 0.25 0.25 0.5 0.5
 am_defaults = 0.5 0.5 0.5 0.5
 phaser_defaults = 0.3 0.3 0.5 0.5
 discont_defaults = 0.8 0.1 0.2 0.2
+tremolo_defaults = 0.6 0.5 0 0
 
-HEADERS = biquad.h  discont.h  echo.h  effect.h  flanger.h  fm.h  gensin.h lfo.h  phaser.h  util.h
+HEADERS = biquad.h  discont.h  echo.h  effect.h  flanger.h  fm.h  gensin.h lfo.h  phaser.h  tremolo.h  util.h
 
 default:
 	@echo "Pick one of" $(effects)

--- a/convert.c
+++ b/convert.c
@@ -23,6 +23,7 @@ typedef unsigned int uint;
 #include "am.h"
 #include "phaser.h"
 #include "discont.h"
+#include "tremolo.h"
 
 struct {
 	float attack, decay, value;
@@ -49,7 +50,7 @@ struct effect {
 	float (*step)(float);
 } effects[] = {
 	EFF(discont), EFF(phaser), EFF(flanger), EFF(echo),
-	EFF(fm), EFF(am),
+	EFF(fm), EFF(am), EFF(tremolo),
 	EFF(magnitude),
 };
 

--- a/tremolo.h
+++ b/tremolo.h
@@ -1,0 +1,31 @@
+//
+// Classic tremolo effect - amplitude modulation of the input signal
+//
+// Unlike the 'am' effect which generates its own signal, this
+// actually modulates the incoming audio.  Very similar to what
+// old Fender amps would call "vibrato" (even though it's really
+// amplitude modulation, not frequency modulation).
+//
+static inline void tremolo_init(float pot1, float pot2, float pot3, float pot4)
+{
+	float lfo = 0.5 + pot1*pot1*10;	// lfo = 0.5 .. 10.5 Hz
+
+	effect_set_lfo(lfo);
+	effect_set_depth(pot2);		// depth = 0 .. 100%
+
+	fprintf(stderr, "tremolo:");
+	fprintf(stderr, " lfo=%g Hz", lfo);
+	fprintf(stderr, " depth=%g\n", pot2);
+}
+
+static inline float tremolo_step(float in)
+{
+	float mod = lfo_step(&effect_lfo, lfo_sinewave);
+
+	// Scale mod from [-1,1] to [1-depth, 1]
+	// When depth=1 and mod=-1, multiplier=0 (full effect)
+	// When depth=0, multiplier=1 always (no effect)
+	float multiplier = 1 - effect_depth * (1 - mod) / 2;
+
+	return in * multiplier;
+}


### PR DESCRIPTION
Classic amplitude modulation of the input signal, unlike the am effect which generates its own signal. This actually modulates the incoming audio like old Fender amps would call vibrato (even though it is really amplitude modulation, not frequency modulation - but that is a classic Fender misnomer).

Uses the shared effect_lfo and effect_depth infrastructure, making it trivially simple. The pot1 controls the LFO rate with the usual quadratic mapping to make the lower frequencies more controllable (0.5-10.5 Hz range), pot2 controls the modulation depth.