### PR TITLE
Small fixes for robustness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,11 @@ input.raw: BassForLinus.mp3
 	ffmpeg -y -v fatal -i $< -f s32le -ar 48000 -ac 1 $@
 
 SeymourDuncan: convert
-	for i in ~/Wav/Seymour\ Duncan/*; do ffmpeg -y -v fatal -i "$$i" -f s32le -ar 48000 -ac 1 pipe:1 | ./convert phaser $(phaser_defaults) | $(PLAY) ; done
+	@if [ ! -d ~/Wav/Seymour\ Duncan ]; then echo "Directory ~/Wav/Seymour Duncan not found"; exit 0; fi
+	for i in ~/Wav/Seymour\ Duncan/*; do \
+		[ -f "$$i" ] || continue; \
+		ffmpeg -y -v fatal -i "$$i" -f s32le -ar 48000 -ac 1 pipe:1 | ./convert phaser $(phaser_defaults) | $(PLAY) ; \
+	done
 
 gensin.h: gensin
 	./gensin > gensin.h

--- a/convert.c
+++ b/convert.c
@@ -79,7 +79,8 @@ static void *modify_pots(void *arg)
 {
 	struct effect *eff = arg;
 
-	for (;;) {
+	for (;;)
+	{
 		char buf[5];
 		int n = read(pot_control, buf, sizeof(buf));
 		if (n <= 0)
@@ -121,6 +122,8 @@ int main(int argc, char **argv)
 		float val = strtof(arg, &endptr);
 		if (endptr != arg) {
 			if (potnr < 4) {
+				if (!isfinite(val))
+					val = 0.5;
 				pots[potnr++] = val;
 				continue;
 			}
@@ -180,6 +183,11 @@ int main(int argc, char **argv)
 	if (output < 0)
 		output = 1;
 
+	if (!eff) {
+		fprintf(stderr, "No effect specified\n");
+		exit(1);
+	}
+
 #ifdef F_SETPIPE_SZ
 	// Limit the output buffer size if we are
 	// writing to a pipe. At least on Linux,
@@ -195,7 +203,8 @@ int main(int argc, char **argv)
 	if (pot_control >= 0)
 		pthread_create(&pot_thread, NULL, modify_pots, eff);
 
-	for (;;) {
+	for (;;)
+	{
 		eff->init(pots);
 		if (make_one_noise(input, output, eff) <= 0)
 			break;


### PR DESCRIPTION
A couple of small tweaks to make the toolkit a bit more robust:

- Handle missing/empty directory in the `SeymourDuncan` Makefile target to avoid shell errors.
- Add a `isfinite()` check in `convert.c` to prevent NaN/Inf from hitting the DSP loop if `atof` receives malformed input.