### PR TITLE
convert: fix declarations after case label

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -85,7 +85,7 @@ static void *modify_pots(void *arg)
 		if (n <= 0)
 			return NULL;
 		switch (buf[0]) {
-		case 'p':
+		case 'p': {
 			unsigned int idx = buf[1]-'0';
 			unsigned int d1 = buf[2]-'0';
 			unsigned int d2 = buf[3]-'0';
@@ -94,6 +94,7 @@ static void *modify_pots(void *arg)
 			pots[idx] = (d1*10+d2) / 100.0;
 			eff->describe(pots);
 			break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
This fixes a build failure with GCC/Clang where declarations directly after a case label are not valid in C.

Repro (Debian 11, GCC): `make convert` fails with:
  error: a label can only be part of a statement and a declaration is not a statement

Also reproducible with clang on macOS.

Fix: wrap the 'p' case body in braces so the declarations are within a block scope.
Tested: `make convert`.