### PR TITLE
Add GTK GUI with real-time pot control

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -548,7 +548,7 @@ class AudioNoisePedal(Gtk.Window):
         shortcuts1 = Gtk.Label()
         shortcuts1.set_markup(
             '<span font="8" foreground="#777777">'
-            'Tab: knob  ←→: ±5  ↑↓: ±1  Space: play  R: reset  1-9: effect'
+            'Tab: knob  ←→: ±5  ↑↓: ±1  Space: play/stop  R: reset  1-9: effect'
             '</span>'
         )
         main_box.pack_start(shortcuts1, False, False, 4)


### PR DESCRIPTION
Adds a GTK-based GUI addressing #60.

**Features:**
- Guitar pedal style interface with 4 rotary knobs
- Real-time pot control using `--control=` interface (ea71138)
- All 9 effects supported (reads from Makefile)
- Smooth mouse drag and scroll wheel for knobs
- Keyboard shortcuts: Tab (select), ←→ (±5), ↑↓ (±1), Space (play), 1-9 (effect), R (reset)
- Works with aplay (~100ms latency) or ffplay fallback

**Requirements:**
```bash
sudo apt install python3-gi python3-gi-cairo gir1.2-gtk-3.0
```

**Usage:**
```bash
python3 gui.py
```

Closes #60