### PR TITLE
Add chorus and tremolo effects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ LDLIBS = -lm
 PYTHON = python3
 PLAY = ffplay -v fatal -nodisp -autoexit -f s32le -ar 48000 -ch_layout mono -i pipe:0
 
-effects = flanger echo fm phaser discont am distortion tube growlingbass
+effects = flanger echo fm phaser discont am distortion tube growlingbass chorus tremolo
 flanger_defaults = 0.6 0.6 0.6 0.6
 echo_defaults = 0.3 0.3 0.3 0.3
 fm_defaults = 0.25 0.25 0.5 0.5
@@ -15,8 +15,10 @@ discont_defaults = 0.8 0.1 0.2 0.2
 distortion_defaults = 0.5 0.6 0.8 0.0
 tube_defaults = 0.5 0.2 0.0 1.0
 growlingbass_defaults = 0.4 0.35 0.0 0.4
+chorus_defaults = 0.3 0.4 0.5 0.7
+tremolo_defaults = 0.5 0.7 0.0 0.0
 
-HEADERS = am.h biquad.h discont.h distortion.h echo.h effect.h flanger.h growlingbass.h  fm.h  gensin.h lfo.h  phaser.h  util.h process.h tube.h
+HEADERS = am.h biquad.h chorus.h discont.h distortion.h echo.h effect.h flanger.h growlingbass.h  fm.h  gensin.h lfo.h  phaser.h  tremolo.h util.h process.h tube.h
 
 default:
 	@echo "Pick one of" $(effects)

--- a/chorus.h
+++ b/chorus.h
@@ -1,0 +1,69 @@
+//
+// Chorus effect - multiple voices with modulated delays
+//
+// Creates a thicker sound by mixing the original signal with
+// multiple slightly detuned copies using LFO-modulated delays.
+//
+static struct {
+	struct lfo_state lfo1, lfo2, lfo3;
+	float delay_ms;
+	float depth;
+	float mix;
+} chorus;
+
+static inline void chorus_describe(float pot[4])
+{
+	fprintf(stderr, " rate=%g Hz", linear(pot[0], 0.1, 5));
+	fprintf(stderr, " delay=%g ms", linear(pot[1], 5, 30));
+	fprintf(stderr, " depth=%g", pot[2]);
+	fprintf(stderr, " mix=%g\n", pot[3]);
+}
+
+static inline void chorus_init(float pot[4])
+{
+	// pot[0]: LFO rate (0.1 - 5 Hz)
+	float rate = linear(pot[0], 0.1, 5);
+
+	// Slightly offset rates for each voice to avoid phase lock
+	set_lfo_freq(&chorus.lfo1, rate);
+	set_lfo_freq(&chorus.lfo2, rate * 1.1);
+	set_lfo_freq(&chorus.lfo3, rate * 0.9);
+
+	// pot[1]: base delay (5 - 30 ms)
+	chorus.delay_ms = linear(pot[1], 5, 30);
+
+	// pot[2]: depth/modulation amount (0 - 100%)
+	chorus.depth = pot[2];
+
+	// pot[3]: wet/dry mix (0 = dry, 1 = full wet)
+	chorus.mix = pot[3];
+}
+
+static inline float chorus_step(float in)
+{
+	// Store input in delay buffer
+	sample_array_write(in);
+
+	// Get three modulated delay values
+	float lfo1 = lfo_step(&chorus.lfo1, lfo_sinewave);
+	float lfo2 = lfo_step(&chorus.lfo2, lfo_sinewave);
+	float lfo3 = lfo_step(&chorus.lfo3, lfo_sinewave);
+
+	float base_samples = chorus.delay_ms * SAMPLES_PER_MSEC;
+	float mod_range = base_samples * chorus.depth * 0.5;
+
+	float d1 = base_samples + lfo1 * mod_range;
+	float d2 = base_samples + lfo2 * mod_range;
+	float d3 = base_samples + lfo3 * mod_range;
+
+	// Read delayed samples
+	float v1 = sample_array_read(d1);
+	float v2 = sample_array_read(d2);
+	float v3 = sample_array_read(d3);
+
+	// Mix voices (average of three delayed signals)
+	float wet = (v1 + v2 + v3) / 3.0f;
+
+	// Blend dry and wet
+	return in * (1.0f - chorus.mix) + wet * chorus.mix;
+}

--- a/convert.c
+++ b/convert.c
@@ -26,6 +26,8 @@
 #include "distortion.h"
 #include "tube.h"
 #include "growlingbass.h"
+#include "chorus.h"
+#include "tremolo.h"
 
 static void magnitude_describe(float pot[4]) { fprintf(stderr, "\n"); }
 static void magnitude_init(float pot[4]) {}
@@ -45,6 +47,8 @@ struct effect {
 	EFF(phaser),
 	EFF(tube),
 	EFF(growlingbass),
+	EFF(chorus),
+	EFF(tremolo),
 
 	/* "Helper" effects */
 	EFF(am),

--- a/tremolo.h
+++ b/tremolo.h
@@ -1,0 +1,42 @@
+//
+// Tremolo effect - amplitude modulation via LFO
+//
+// Classic guitar amp tremolo effect that modulates volume
+// using a sine or triangle wave LFO.
+//
+static struct {
+	struct lfo_state lfo;
+	float depth;
+	enum lfo_type wave;
+} tremolo;
+
+static inline void tremolo_describe(float pot[4])
+{
+	fprintf(stderr, " rate=%g Hz", linear(pot[0], 0.5, 15));
+	fprintf(stderr, " depth=%g", pot[1]);
+	fprintf(stderr, " wave=%s\n", pot[2] < 0.5 ? "sine" : "triangle");
+}
+
+static inline void tremolo_init(float pot[4])
+{
+	// pot[0]: LFO rate (0.5 - 15 Hz)
+	set_lfo_freq(&tremolo.lfo, linear(pot[0], 0.5, 15));
+
+	// pot[1]: depth (0 - 100%)
+	tremolo.depth = pot[1];
+
+	// pot[2]: waveform (0-0.5 = sine, 0.5-1 = triangle)
+	tremolo.wave = pot[2] < 0.5 ? lfo_sinewave : lfo_triangle;
+}
+
+static inline float tremolo_step(float in)
+{
+	// Get LFO value (-1 to 1), convert to gain multiplier
+	float lfo = lfo_step(&tremolo.lfo, tremolo.wave);
+
+	// Convert LFO to amplitude multiplier: 1 - depth*(1-lfo)/2
+	// When lfo=1, mult=1; when lfo=-1, mult=1-depth
+	float mult = 1.0f - tremolo.depth * (1.0f - lfo) * 0.5f;
+
+	return in * mult;
+}


### PR DESCRIPTION
Two new effects using the current describe/init(pot[4])/step interface:

**Chorus** - three-voice LFO-modulated delay for thickening:
- pot[0]: rate (0.1-5 Hz), pot[1]: delay (5-30 ms)
- pot[2]: depth, pot[3]: wet/dry mix
- Three slightly detuned LFO voices avoid phase lock

**Tremolo** - LFO amplitude modulation:
- pot[0]: rate (0.5-15 Hz), pot[1]: depth
- pot[2]: waveform (sine/triangle)

Both use the linear() macro for pot ranges. Replaces stale PRs #45 and #46 which were against the old interface.