### PR TITLE
Add foldback and diode clipper waveshaper primitives

### DIFF
--- a/waveshaper.h
+++ b/waveshaper.h
@@ -1,0 +1,39 @@
+//
+// Extended waveshaper primitives for guitar effects
+//
+// These complement distortion.h (soft_clip, hard_clip, asymmetric_clip)
+// with additional clipping styles for fuzz and synth tones.
+//
+
+//
+// Foldback distortion - signal folds back when exceeding threshold
+// Creates complex harmonics, useful for synth-style fuzz
+//
+static inline float fold_back(float x, float threshold)
+{
+	int iterations = 0;
+
+	if (threshold <= 0)
+		return 0;
+
+	// Limit iterations to prevent infinite loop on extreme input
+	while ((x > threshold || x < -threshold) && iterations++ < 16) {
+		if (x > threshold)
+			x = 2 * threshold - x;
+		else
+			x = -2 * threshold - x;
+	}
+	return x;
+}
+
+//
+// Diode clipper emulation - asymmetric soft clip
+// Approximates silicon diode clipping (forward voltage ~0.6V)
+// ratio controls asymmetry (1.0 = symmetric, 0.5 = half negative clip)
+//
+static inline float diode_clip(float x, float ratio)
+{
+	float pos = limit_value(x);
+	float neg = limit_value(x * ratio) / ratio;
+	return x >= 0 ? pos : neg;
+}


### PR DESCRIPTION
Two new waveshaper functions that complement distortion.h:

**fold_back(x, threshold)** - foldback distortion for synth-style fuzz. Signal folds back when exceeding threshold, creating complex harmonics. Iteration-limited (16 max) to prevent runaway on extreme input.

**diode_clip(x, ratio)** - asymmetric soft clip emulating silicon diode clipping (~0.6V forward voltage). Uses limit_value() for the soft clip core. ratio controls asymmetry (1.0 = symmetric, 0.5 = half negative clip).

These are standalone primitives in waveshaper.h for use in other effects, not registered as their own effect. Replaces stale PR #64 which included a tube_clip that now overlaps with tube.h.